### PR TITLE
Bump and rename sslcontext-kicktart to ayza

### DIFF
--- a/libscompile/pom.xml
+++ b/libscompile/pom.xml
@@ -48,8 +48,8 @@
         </dependency>
         <dependency>
             <groupId>io.github.hakky54</groupId>
-            <artifactId>sslcontext-kickstart-for-pem</artifactId>
-            <version>8.3.6</version>
+            <artifactId>ayza-for-pem</artifactId>
+            <version>10.0.0</version>
         </dependency>
         <dependency>
             <groupId>net.bramp.ffmpeg</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -60,8 +60,8 @@
         </dependency>
         <dependency>
             <groupId>io.github.hakky54</groupId>
-            <artifactId>sslcontext-kickstart-for-pem</artifactId>
-            <version>8.2.0</version>
+            <artifactId>ayza-for-pem</artifactId>
+            <version>10.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
The library has been renamed from sslcontext-kickstart to [ayza](https://github.com/Hakky54/ayza). The latest version is 10.0.0

Sorry for the inconvenience